### PR TITLE
fix: payload size with contiguous blocks

### DIFF
--- a/elf2uf2.c
+++ b/elf2uf2.c
@@ -199,7 +199,7 @@ static void report_family(void)
             return;
         }
     }
-    printf("creating UF2 file for the unknown family id 0x%08lx\n", fam_id);
+    printf("creating UF2 file for the unknown family id 0x%08llx\n", fam_id);
 }
 
 static void print_all_families(void)

--- a/elf2uf2.c
+++ b/elf2uf2.c
@@ -320,9 +320,8 @@ static int copy_data(FILE* elf_file)
     UF2_Block.magicEnd = 0x0AB16F30;
     UF2_Block.flags = 0x00002000;
     UF2_Block.fileSize = (uint32_t)(fam_id & 0xffffffff);
-    UF2_Block.payloadSize = payload_size;
     UF2_Block.blockNo = 0;
-    UF2_Block.numBlocks =  num;
+    UF2_Block.numBlocks = num;
 
     // create UF2 file
     uf2_file = fopen(uf2_name, "wb");
@@ -360,6 +359,7 @@ static int copy_data(FILE* elf_file)
             // write a UF2 Block
             memset(UF2_Block.data, 0, 476);
             memcpy(UF2_Block.data, buffer, copy_size);
+            UF2_Block.payloadSize = copy_size;
             cur_mem->target_size = cur_mem->target_size - copy_size;
             cur_mem->target_start_addr = cur_mem->target_start_addr + copy_size;
             if(copy_size < payload_size)
@@ -392,6 +392,7 @@ static int copy_data(FILE* elf_file)
                             return 27;
                         }
                         memcpy(&UF2_Block.data[copy_size], buffer, bytes_to_fill);
+                        UF2_Block.payloadSize = UF2_Block.payloadSize + bytes_to_fill;
                         cur_mem->target_size = cur_mem->target_size - bytes_to_fill;
                         cur_mem->target_start_addr = cur_mem->target_start_addr + bytes_to_fill;
                     }


### PR DESCRIPTION
When contiguous blocks add up to less than the configured payload size, it would produce blocks larger than the difference between start addresses in 2 payload blocks.

For example (output from `readelf -l`):
```
  Type           Offset   VirtAddr   PhysAddr   FileSiz MemSiz  Flg Align
  LOAD           0x030000 0x90000000 0x700002b0 0x115ff0 0x115ff0 R E 0x10000
  LOAD           0x1462a0 0x701162a0 0x701162a0 0x000d8 0x000d8 R E 0x10000
  LOAD           0x155ff0 0x90115ff0 0x70116378 0x00008 0x00008 R   0x10000
  LOAD           0x160000 0x24000000 0x70116380 0x0044c 0x0044c RW  0x10000
```

In this case, `elf2uf2` would produce these blocks (only relevant blocks shown):
```
Block 4706/4712 @0x70116200 (len=256), Family: ST STM32H7xx
Block 4707/4712 @0x70116300 (len=256), Family: ST STM32H7xx
Block 4708/4712 @0x70116380 (len=256), Family: ST STM32H7xx
Block 4709/4712 @0x70116480 (len=256), Family: ST STM32H7xx
Block 4710/4712 @0x70116580 (len=256), Family: ST STM32H7xx
Block 4711/4712 @0x70116680 (len=256), Family: ST STM32H7xx
Block 4712/4712 @0x70116780 (len=256), Family: ST STM32H7xx
```

This would cause block `4707` and `4708` to overlap, and thus not be flashed properly.

With this change, the payload is adjusted:
```
Block 4706/4712 @0x70116200 (len=256), Family: ST STM32H7xx
Block 4707/4712 @0x70116300 (len=128), Family: ST STM32H7xx
Block 4708/4712 @0x70116380 (len=256), Family: ST STM32H7xx
Block 4709/4712 @0x70116480 (len=256), Family: ST STM32H7xx
Block 4710/4712 @0x70116580 (len=256), Family: ST STM32H7xx
Block 4711/4712 @0x70116680 (len=256), Family: ST STM32H7xx
Block 4712/4712 @0x70116780 (len=76), Family: ST STM32H7xx
```